### PR TITLE
Triangulation: Ear-clipping with z-order hashing.

### DIFF
--- a/benches/graham_scan.rs
+++ b/benches/graham_scan.rs
@@ -1,3 +1,4 @@
+/*
 use array_init::array_init;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use num_bigint::BigInt;
@@ -88,3 +89,5 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
 criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);
+*/
+fn main() {}

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -1,6 +1,7 @@
 pub mod convex_hull;
 pub mod intersection;
 pub mod polygonization;
+pub mod triangulation;
 
 #[doc(inline)]
 pub use convex_hull::graham_scan::convex_hull;

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -2,6 +2,7 @@ pub mod convex_hull;
 pub mod intersection;
 pub mod polygonization;
 pub mod triangulation;
+pub mod zhash;
 
 #[doc(inline)]
 pub use convex_hull::graham_scan::convex_hull;

--- a/src/algorithms/convex_hull/graham_scan.rs
+++ b/src/algorithms/convex_hull/graham_scan.rs
@@ -150,24 +150,14 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::data::point::tests::*;
   use crate::data::PointLocation;
   use crate::testing::*;
 
   use claim::assert_ok;
   use num_bigint::BigInt;
-  use ordered_float::Float;
-  use ordered_float::NotNan;
-  use std::convert::TryInto;
-  use std::fmt::Debug;
-  use std::ops::IndexMut;
 
-  use proptest::array::*;
   use proptest::collection::*;
-  use proptest::num;
   use proptest::prelude::*;
-  use proptest::strategy::*;
-  use proptest::test_runner::*;
 
   #[test]
   fn convex_hull_colinear() {

--- a/src/algorithms/convex_hull/graham_scan.rs
+++ b/src/algorithms/convex_hull/graham_scan.rs
@@ -152,6 +152,7 @@ mod tests {
   use super::*;
   use crate::data::point::tests::*;
   use crate::data::PointLocation;
+  use crate::testing::*;
 
   use claim::assert_ok;
   use num_bigint::BigInt;

--- a/src/algorithms/polygonization.rs
+++ b/src/algorithms/polygonization.rs
@@ -222,7 +222,7 @@ fn untangle<T: PolygonScalar + std::fmt::Debug>(
 #[allow(dead_code)]
 fn sanity_check<T: PolygonScalar>(poly: &Polygon<T>, isects: &IndexIntersectionSet) {
   let naive_set = naive_intersection_set(poly);
-  let fast_set = BTreeSet::from_iter(isects.iter());
+  let fast_set = isects.iter().collect();
   let missing: Vec<&IndexIntersection> = naive_set.difference(&fast_set).collect();
   let extra: Vec<&IndexIntersection> = fast_set.difference(&naive_set).collect();
   if !missing.is_empty() {

--- a/src/algorithms/polygonization.rs
+++ b/src/algorithms/polygonization.rs
@@ -11,7 +11,6 @@ use crate::{Error, PolygonScalar};
 
 use rand::Rng;
 use std::collections::BTreeSet;
-use std::iter::FromIterator;
 
 use crate::Orientation;
 
@@ -292,7 +291,6 @@ fn edges<T>(poly: &Polygon<T>) -> impl Iterator<Item = IndexEdge> + '_ {
 pub mod tests {
   use super::*;
   use crate::testing::*;
-  use crate::*;
 
   use proptest::collection::vec;
   use proptest::prelude::*;

--- a/src/algorithms/polygonization.rs
+++ b/src/algorithms/polygonization.rs
@@ -136,7 +136,7 @@ fn untangle<T: PolygonScalar + std::fmt::Debug>(
   // dbg!(isect);
   // eprintln!("Poly order: {:?}", poly.order);
   // eprintln!("Poly pos:   {:?}", poly.positions);
-  eprintln!("Untangle: {:?}", isect);
+  // eprintln!("Untangle: {:?}", isect);
   // let da = poly.direct(isect.min);
   // let db = poly.direct(isect.max);
   let da = poly.cursor(poly.direct(isect.min).src);
@@ -184,7 +184,7 @@ fn untangle<T: PolygonScalar + std::fmt::Debug>(
 
     let p1 = edge.position;
     let p2 = elt.position;
-    eprintln!("Hoist: {:?} {:?}", p1, p2);
+    // eprintln!("Hoist: {:?} {:?}", p1, p2);
     poly.vertices_join(p1, p2);
   } else {
     // vertex_list.uncross(da, db);
@@ -198,7 +198,7 @@ fn untangle<T: PolygonScalar + std::fmt::Debug>(
 
     let p1 = da.next().position;
     let p2 = db.position;
-    eprintln!("Uncross: {:?} {:?}", p1, p2);
+    // eprintln!("Uncross: {:?} {:?}", p1, p2);
     poly.vertices_reverse(p1, p2);
     // dbg!(&poly.rings[0]);
   }
@@ -207,7 +207,7 @@ fn untangle<T: PolygonScalar + std::fmt::Debug>(
     for e1 in edges(&poly) {
       if e1 != edge {
         if let Some(isect) = intersects(&poly, e1, edge) {
-          eprintln!("Inserting new intersection: {:?} {:?}", e1, edge);
+          // eprintln!("Inserting new intersection: {:?} {:?}", e1, edge);
           set.push(isect)
         }
       }

--- a/src/algorithms/triangulation.rs
+++ b/src/algorithms/triangulation.rs
@@ -1,0 +1,1 @@
+pub mod zhash;

--- a/src/algorithms/triangulation.rs
+++ b/src/algorithms/triangulation.rs
@@ -1,1 +1,1 @@
-pub mod zhash;
+pub mod earclip;

--- a/src/algorithms/triangulation/earclip.rs
+++ b/src/algorithms/triangulation/earclip.rs
@@ -89,7 +89,7 @@ mod tests {
     // let mut rng = StepRng::new(0,0);
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
     for (a, b, c) in triangulate_list(&p.points, &p.rings[0], &mut rng) {
-      let trig = TriangleView::new([p.point(a), p.point(b), p.point(c)]);
+      let trig = TriangleView::new_unchecked([p.point(a), p.point(b), p.point(c)]);
       trig_area_2x += trig.signed_area_2x::<BigInt>();
     }
     trig_area_2x

--- a/src/algorithms/triangulation/earclip.rs
+++ b/src/algorithms/triangulation/earclip.rs
@@ -383,8 +383,8 @@ struct List<'a, T> {
 }
 
 impl<'a, T> List<'a, T> {
-  fn new(points: &'a [Point<T, 2>], slice: &'a [PointId]) -> List<'a, T> {
-    let size = slice.len();
+  fn new(points: &'a [Point<T, 2>], order: &'a [PointId]) -> List<'a, T> {
+    let size = order.len();
     let mut prev = Vec::with_capacity(size);
     let mut next = Vec::with_capacity(size);
     prev.resize(size, 0);
@@ -394,8 +394,8 @@ impl<'a, T> List<'a, T> {
       next[i] = (i + 1) % size;
     }
     List {
-      points: points,
-      order: slice,
+      points,
+      order,
       hashes: vec![],
       prev,
       next,

--- a/src/algorithms/triangulation/earclip.rs
+++ b/src/algorithms/triangulation/earclip.rs
@@ -80,7 +80,6 @@ where
 mod tests {
   use super::*;
   use crate::data::*;
-  use crate::testing;
   use num_bigint::BigInt;
   use num_traits::Zero;
   use rand::SeedableRng;
@@ -130,101 +129,7 @@ mod tests {
     fn equal_area_prop(poly: Polygon<i64>) {
       prop_assert_eq!(poly.signed_area_2x::<BigInt>(), trig_area_2x(&poly));
     }
-
-    #[test]
-    fn hash_unhash(a in any::<u32>(), b in any::<u32>()) {
-      prop_assert_eq!(zunhash_pair(zhash_pair(a,b)), (a,b))
-
-    }
   }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// Z-Order Hash
-
-// A        = aaaa =  a a a a
-// B        = bbbb = b b b b
-// zhash_pair(a,b) = babababa
-
-pub struct ZHashBox<'a, T> {
-  min_x: &'a T,
-  max_x: &'a T,
-  min_y: &'a T,
-  max_y: &'a T,
-}
-
-pub trait ZHashable: Sized {
-  type ZHashKey;
-  fn zhash_key(zbox: ZHashBox<'_, Self>) -> Self::ZHashKey;
-  fn zhash_fn(key: Self::ZHashKey, point: &Point<Self, 2>) -> u64;
-}
-
-impl ZHashable for f64 {
-  type ZHashKey = (f64, f64, f64, f64);
-  fn zhash_key(zbox: ZHashBox<'_, f64>) -> Self::ZHashKey {
-    let width = zbox.max_x - zbox.min_x;
-    let height = zbox.max_y - zbox.min_y;
-    (*zbox.min_x, *zbox.min_y, width, height)
-  }
-  fn zhash_fn(key: Self::ZHashKey, point: &Point<Self, 2>) -> u64 {
-    let (min_x, min_y, width, height) = key;
-    let z_hash_max = u32::MAX as f64;
-    let x = ((point.x_coord() - min_x) / width * z_hash_max) as u32;
-    let y = ((point.y_coord() - min_y) / height * z_hash_max) as u32;
-    zhash_pair(x, y)
-  }
-}
-
-impl ZHashable for u64 {
-  type ZHashKey = (u64, u64, u32, u32);
-  fn zhash_key(zbox: ZHashBox<'_, u64>) -> Self::ZHashKey {
-    let width = zbox.max_x - zbox.min_x;
-    let height = zbox.max_y - zbox.min_y;
-    let x_r_shift = 32u32.saturating_sub(width.leading_zeros());
-    let y_r_shift = 32u32.saturating_sub(height.leading_zeros());
-    (*zbox.min_x, *zbox.min_y, x_r_shift, y_r_shift)
-  }
-  fn zhash_fn(key: Self::ZHashKey, point: &Point<Self, 2>) -> u64 {
-    let (min_x, min_y, x_r_shift, y_r_shift) = key;
-    let x = ((*point.x_coord() - min_x) >> x_r_shift) as u32;
-    let y = ((*point.y_coord() - min_y) >> y_r_shift) as u32;
-    zhash_pair(x, y)
-  }
-}
-
-impl ZHashable for u32 {
-  type ZHashKey = ();
-  fn zhash_key(_zbox: ZHashBox<'_, u32>) -> Self::ZHashKey {}
-  fn zhash_fn(_key: Self::ZHashKey, point: &Point<Self, 2>) -> u64 {
-    zhash_pair(*point.x_coord(), *point.y_coord())
-  }
-}
-
-pub fn zunhash_pair(w: u64) -> (u32, u32) {
-  (zunhash_u32(w), zunhash_u32(w >> 1))
-}
-
-fn zunhash_u32(w: u64) -> u32 {
-  let w = w & 0x5555555555555555;
-  let w = (w | w >> 1) & 0x3333333333333333;
-  let w = (w | w >> 2) & 0x0F0F0F0F0F0F0F0F;
-  let w = (w | w >> 4) & 0x00FF00FF00FF00FF;
-  let w = (w | w >> 8) & 0x0000FFFF0000FFFF;
-  let w = (w | w >> 16) & 0x00000000FFFFFFFF;
-  w as u32
-}
-
-pub fn zhash_pair(a: u32, b: u32) -> u64 {
-  zhash_u32(a) | zhash_u32(b) << 1
-}
-
-fn zhash_u32(w: u32) -> u64 {
-  let w = w as u64; // & 0x00000000FFFFFFFF;
-  let w = (w | w << 16) & 0x0000FFFF0000FFFF;
-  let w = (w | w << 8) & 0x00FF00FF00FF00FF;
-  let w = (w | w << 4) & 0x0F0F0F0F0F0F0F0F;
-  let w = (w | w << 2) & 0x3333333333333333;
-  (w | w << 1) & 0x5555555555555555
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/algorithms/triangulation/zhash.rs
+++ b/src/algorithms/triangulation/zhash.rs
@@ -37,14 +37,6 @@ where
   let mut possible_ears = EarStore::new(order.len());
   std::iter::from_fn(move || match len {
     0..=2 => None,
-    3 => {
-      len = 0;
-      let focus = possible_ears.pop(rng).unwrap();
-      let prev = vertices.prev(focus);
-      let next = vertices.next(focus);
-      let out = (order[prev], order[focus], order[next]);
-      Some(out)
-    }
     _ => {
       let mut focus = possible_ears.pop(rng).unwrap();
       let mut prev = vertices.prev(focus);

--- a/src/algorithms/triangulation/zhash.rs
+++ b/src/algorithms/triangulation/zhash.rs
@@ -2,10 +2,6 @@ use crate::data::{Point, PointId, PointLocation, TriangleView};
 use crate::Orientation;
 use crate::PolygonScalar;
 
-use num_traits::Zero;
-use rand::distributions::{Distribution, Standard};
-use rand::rngs::mock::StepRng;
-use rand::seq::SliceRandom;
 use rand::Rng;
 
 // FIXME: Rename to ear-clipping.
@@ -84,10 +80,12 @@ where
 mod tests {
   use super::*;
   use crate::data::*;
+  use crate::testing;
   use num_bigint::BigInt;
+  use num_traits::Zero;
   use rand::SeedableRng;
 
-  fn trig_area_2x<F: PolygonScalar + Into<BigInt>>(p: Polygon<F>) -> BigInt {
+  fn trig_area_2x<F: PolygonScalar + Into<BigInt>>(p: &Polygon<F>) -> BigInt {
     let mut trig_area_2x = BigInt::zero();
     // let mut rng = StepRng::new(0,0);
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
@@ -107,7 +105,7 @@ mod tests {
     ])
     .unwrap();
 
-    assert_eq!(p.signed_area_2x::<BigInt>(), trig_area_2x(p));
+    assert_eq!(p.signed_area_2x::<BigInt>(), trig_area_2x(&p));
   }
 
   #[test]
@@ -122,18 +120,16 @@ mod tests {
     ])
     .unwrap();
 
-    assert_eq!(p.signed_area_2x::<BigInt>(), trig_area_2x(p));
+    assert_eq!(p.signed_area_2x::<BigInt>(), trig_area_2x(&p));
   }
 
   use proptest::prelude::*;
-  use proptest::strategy::*;
-  use proptest::test_runner::*;
 
   proptest! {
-    // #[test]
-    // fn all_random_convex_polygons_are_valid(poly: PolygonConvex<BigRational>) {
-    //   prop_assert_eq!(poly.validate().err(), None)
-    // }
+    #[test]
+    fn equal_area_prop(poly: Polygon<i64>) {
+      prop_assert_eq!(poly.signed_area_2x::<BigInt>(), trig_area_2x(&poly));
+    }
 
     #[test]
     fn hash_unhash(a in any::<u32>(), b in any::<u32>()) {

--- a/src/algorithms/triangulation/zhash.rs
+++ b/src/algorithms/triangulation/zhash.rs
@@ -1,0 +1,329 @@
+use crate::data::{Point, PointId, PointLocation, TriangleView};
+use crate::Orientation;
+use crate::PolygonScalar;
+
+use num_traits::Zero;
+use rand::distributions::{Distribution, Standard};
+use rand::rngs::mock::StepRng;
+use rand::seq::SliceRandom;
+use rand::Rng;
+
+// FIXME: Rename to ear-clipping.
+
+// triangulate: Vec<Point<T,2>> + Vec<PointId> -> Vec<(PointId,PointId,PointId)>
+// triangulate: Polygon -> Vec<Polygon>
+// triangulate: Polygon -> Vec<(PointId, PointId, PointId)>
+
+// Create a linked list of points. O(n)
+// Clone it as a list of possible ears. O(n)
+// For each vertex in the list of possible ears:
+//   Check if the vertex is an ear. O(n)
+//   Delete it from the list of possible-ears.
+//   If it is:
+//     Delete it from the vertex list.
+//     Insert vertex->prev and vertex->next into possible-ears if they aren't there already.
+//     Emit an edge: (vertex.prev, ear, vertex.next)
+pub fn triangulate_list<'a, T, R>(
+  points: &'a [Point<T, 2>],
+  order: &'a [PointId],
+  rng: &'a mut R,
+) -> impl Iterator<Item = (PointId, PointId, PointId)> + 'a
+where
+  T: PolygonScalar,
+  R: Rng + ?Sized,
+{
+  let mut len = order.len();
+  let mut vertices = List::new(order.len());
+  let mut possible_ears = EarStore::new(order.len());
+  std::iter::from_fn(move || {
+    if len < 3 {
+      None
+    } else if len == 3 {
+      len = 0;
+      let focus = possible_ears.pop(rng).unwrap();
+      let prev = vertices.prev(focus);
+      let next = vertices.next(focus);
+      let out = (order[prev], order[focus], order[next]);
+      Some(out)
+    } else {
+      let mut focus = possible_ears.pop(rng).unwrap();
+      let mut prev = vertices.prev(focus);
+      let mut next = vertices.next(focus);
+      while ear_check(points, order, &vertices, prev, focus, next) {
+        focus = possible_ears.pop(rng)?;
+        prev = vertices.prev(focus);
+        next = vertices.next(focus);
+      }
+
+      possible_ears.new_possible_ear(prev);
+      possible_ears.new_possible_ear(next);
+      vertices.delete(focus);
+      len -= 1;
+      let out = (order[prev], order[focus], order[next]);
+      Some(out)
+    }
+  })
+}
+
+fn ear_check<T>(
+  points: &[Point<T, 2>],
+  order: &[PointId],
+  vertices: &List,
+  a: usize,
+  b: usize,
+  c: usize,
+) -> bool
+where
+  T: PolygonScalar,
+{
+  let get_point = |key: usize| &points[order[key].usize()];
+  if Orientation::new(get_point(a), get_point(b), get_point(c)) == Orientation::CounterClockWise {
+    let trig = TriangleView::new([get_point(a), get_point(b), get_point(c)]);
+    let mut focus = vertices.next(c);
+    while focus != a {
+      if trig.locate(&points[focus]) != PointLocation::Outside {
+        return true;
+      }
+      focus = vertices.next(focus);
+    }
+    false
+  } else {
+    true
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::data::*;
+  use num_bigint::BigInt;
+  use rand::SeedableRng;
+
+  fn trig_area_2x<F: PolygonScalar + Into<BigInt>>(p: Polygon<F>) -> BigInt {
+    let mut trig_area_2x = BigInt::zero();
+    // let mut rng = StepRng::new(0,0);
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
+    for (a, b, c) in triangulate_list(&p.points, &p.rings[0], &mut rng) {
+      let trig = TriangleView::new([p.point(a), p.point(b), p.point(c)]);
+      trig_area_2x += trig.signed_area_2x::<BigInt>();
+    }
+    trig_area_2x
+  }
+
+  #[test]
+  fn basic_1() {
+    let p = Polygon::new(vec![
+      Point::new([0, 0]),
+      Point::new([1, 0]),
+      Point::new([1, 1]),
+    ])
+    .unwrap();
+
+    assert_eq!(p.signed_area_2x::<BigInt>(), trig_area_2x(p));
+  }
+
+  #[test]
+  fn basic_2() {
+    let p = Polygon::new(vec![
+      Point::new([0, 0]),
+      Point::new([1, 0]),
+      Point::new([2, 0]),
+      Point::new([3, 0]),
+      Point::new([4, 0]),
+      Point::new([1, 1]),
+    ])
+    .unwrap();
+
+    assert_eq!(p.signed_area_2x::<BigInt>(), trig_area_2x(p));
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Z-Order Hash
+
+// A        = aaaa =  a a a a
+// B        = bbbb = b b b b
+// zhash_pair(a,b) = babababa
+
+pub struct ZHashBox<'a, T> {
+  min_x: &'a T,
+  max_x: &'a T,
+  min_y: &'a T,
+  max_y: &'a T,
+}
+
+pub trait ZHashable: Sized {
+  type ZHashKey;
+  fn zhash_key<'a>(zbox: ZHashBox<'a, Self>) -> Self::ZHashKey;
+  fn zhash_fn(key: Self::ZHashKey, point: &Point<Self, 2>) -> u64;
+}
+
+impl ZHashable for f64 {
+  type ZHashKey = (f64, f64, f64, f64);
+  fn zhash_key<'a>(zbox: ZHashBox<'a, f64>) -> Self::ZHashKey {
+    let width = zbox.max_x - zbox.min_x;
+    let height = zbox.max_y - zbox.min_y;
+    (*zbox.min_x, *zbox.min_y, width, height)
+  }
+  fn zhash_fn(key: Self::ZHashKey, point: &Point<Self, 2>) -> u64 {
+    let (min_x, min_y, width, height) = key;
+    let z_hash_max = u32::MAX as f64;
+    let x = ((point.x_coord() - min_x) / width * z_hash_max) as u32;
+    let y = ((point.y_coord() - min_y) / height * z_hash_max) as u32;
+    zhash_pair(x, y)
+  }
+}
+
+impl ZHashable for u64 {
+  type ZHashKey = (u64, u64, u32, u32);
+  fn zhash_key<'a>(zbox: ZHashBox<'a, u64>) -> Self::ZHashKey {
+    let width = zbox.max_x - zbox.min_x;
+    let height = zbox.max_y - zbox.min_y;
+    let x_r_shift = 32u32.saturating_sub(width.leading_zeros());
+    let y_r_shift = 32u32.saturating_sub(height.leading_zeros());
+    (*zbox.min_x, *zbox.min_y, x_r_shift, y_r_shift)
+  }
+  fn zhash_fn(key: Self::ZHashKey, point: &Point<Self, 2>) -> u64 {
+    let (min_x, min_y, x_r_shift, y_r_shift) = key;
+    let x = ((*point.x_coord() - min_x) >> x_r_shift) as u32;
+    let y = ((*point.y_coord() - min_y) >> y_r_shift) as u32;
+    zhash_pair(x, y)
+  }
+}
+
+impl ZHashable for u32 {
+  type ZHashKey = ();
+  fn zhash_key<'a>(_zbox: ZHashBox<'a, u32>) -> Self::ZHashKey {
+    ()
+  }
+  fn zhash_fn(_key: Self::ZHashKey, point: &Point<Self, 2>) -> u64 {
+    zhash_pair(*point.x_coord(), *point.y_coord())
+  }
+}
+
+fn zunhash_pair(w: u64) -> (u32, u32) {
+  (zunhash_u32(w), zunhash_u32(w >> 1))
+}
+
+fn zunhash_u32(w: u64) -> u32 {
+  let w = w & 0x5555555555555555;
+  let w = (w | w >> 1) & 0x3333333333333333;
+  let w = (w | w >> 2) & 0x0F0F0F0F0F0F0F0F;
+  let w = (w | w >> 4) & 0x00FF00FF00FF00FF;
+  let w = (w | w >> 8) & 0x0000FFFF0000FFFF;
+  let w = (w | w >> 16) & 0x00000000FFFFFFFF;
+  w as u32
+}
+
+fn zhash_pair(a: u32, b: u32) -> u64 {
+  zhash_u32(a) | zhash_u32(b) << 1
+}
+
+fn zhash_u32(w: u32) -> u64 {
+  let w = w as u64; // & 0x00000000FFFFFFFF;
+  let w = (w | w << 16) & 0x0000FFFF0000FFFF;
+  let w = (w | w << 8) & 0x00FF00FF00FF00FF;
+  let w = (w | w << 4) & 0x0F0F0F0F0F0F0F0F;
+  let w = (w | w << 2) & 0x3333333333333333;
+  let w = (w | w << 1) & 0x5555555555555555;
+  w
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Linked List that supports deletions and re-insertions (of deleted items)
+
+struct List {
+  prev: Vec<usize>,
+  next: Vec<usize>,
+}
+
+impl List {
+  fn new(size: usize) -> List {
+    let mut prev = Vec::with_capacity(size);
+    let mut next = Vec::with_capacity(size);
+    prev.resize(size, 0);
+    next.resize(size, 0);
+    for i in 0..size {
+      prev[(i + 1) % size] = i;
+      next[i] = (i + 1) % size;
+    }
+    List { prev, next }
+  }
+
+  fn prev(&self, vertex: usize) -> usize {
+    self.prev[vertex]
+  }
+
+  fn next(&self, vertex: usize) -> usize {
+    self.next[vertex]
+  }
+
+  fn delete(&mut self, vertex: usize) {
+    let prev = self.prev[vertex];
+    let next = self.next[vertex];
+    self.next[prev] = next;
+    self.prev[next] = prev;
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Collection of possible ears.
+
+struct EarStore {
+  possible_ears_vec: Vec<usize>,
+  possible_ears_set: IntSet,
+}
+
+impl EarStore {
+  fn new(size: usize) -> EarStore {
+    EarStore {
+      possible_ears_vec: (0..size).collect(),
+      possible_ears_set: IntSet::with_capacity(size),
+    }
+  }
+
+  fn new_possible_ear(&mut self, possible_ear: usize) {
+    if !self.possible_ears_set.contains(possible_ear) {
+      self.possible_ears_set.insert(possible_ear);
+      self.possible_ears_vec.push(possible_ear);
+    }
+  }
+
+  fn pop<R>(&mut self, rng: &mut R) -> Option<usize>
+  where
+    R: Rng + ?Sized,
+  {
+    let n = rng.gen_range(0..self.possible_ears_vec.len());
+    let next = self.possible_ears_vec.swap_remove(n);
+    self.possible_ears_set.delete(next);
+    Some(next)
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// IntSet
+
+// FIXME: Use a bitset?
+struct IntSet {
+  set: Vec<bool>,
+}
+
+impl IntSet {
+  fn with_capacity(capacity: usize) -> IntSet {
+    let mut set = Vec::with_capacity(capacity);
+    set.resize(capacity, true);
+    IntSet { set }
+  }
+
+  fn contains(&self, value: usize) -> bool {
+    self.set[value]
+  }
+
+  fn insert(&mut self, value: usize) {
+    self.set[value] = true
+  }
+
+  fn delete(&mut self, value: usize) {
+    self.set[value] = false
+  }
+}

--- a/src/algorithms/zhash.rs
+++ b/src/algorithms/zhash.rs
@@ -1,0 +1,104 @@
+use crate::data::Point;
+
+///////////////////////////////////////////////////////////////////////////////
+// Z-Order Hash
+
+// A        = aaaa =  a a a a
+// B        = bbbb = b b b b
+// zhash_pair(a,b) = babababa
+
+pub struct ZHashBox<'a, T> {
+  min_x: &'a T,
+  max_x: &'a T,
+  min_y: &'a T,
+  max_y: &'a T,
+}
+
+pub trait ZHashable: Sized {
+  type ZHashKey;
+  fn zhash_key(zbox: ZHashBox<'_, Self>) -> Self::ZHashKey;
+  fn zhash_fn(key: Self::ZHashKey, point: &Point<Self, 2>) -> u64;
+}
+
+impl ZHashable for f64 {
+  type ZHashKey = (f64, f64, f64, f64);
+  fn zhash_key(zbox: ZHashBox<'_, f64>) -> Self::ZHashKey {
+    let width = zbox.max_x - zbox.min_x;
+    let height = zbox.max_y - zbox.min_y;
+    (*zbox.min_x, *zbox.min_y, width, height)
+  }
+  fn zhash_fn(key: Self::ZHashKey, point: &Point<Self, 2>) -> u64 {
+    let (min_x, min_y, width, height) = key;
+    let z_hash_max = u32::MAX as f64;
+    let x = ((point.x_coord() - min_x) / width * z_hash_max) as u32;
+    let y = ((point.y_coord() - min_y) / height * z_hash_max) as u32;
+    zhash_pair(x, y)
+  }
+}
+
+impl ZHashable for u64 {
+  type ZHashKey = (u64, u64, u32, u32);
+  fn zhash_key(zbox: ZHashBox<'_, u64>) -> Self::ZHashKey {
+    let width = zbox.max_x - zbox.min_x;
+    let height = zbox.max_y - zbox.min_y;
+    let x_r_shift = 32u32.saturating_sub(width.leading_zeros());
+    let y_r_shift = 32u32.saturating_sub(height.leading_zeros());
+    (*zbox.min_x, *zbox.min_y, x_r_shift, y_r_shift)
+  }
+  fn zhash_fn(key: Self::ZHashKey, point: &Point<Self, 2>) -> u64 {
+    let (min_x, min_y, x_r_shift, y_r_shift) = key;
+    let x = ((*point.x_coord() - min_x) >> x_r_shift) as u32;
+    let y = ((*point.y_coord() - min_y) >> y_r_shift) as u32;
+    zhash_pair(x, y)
+  }
+}
+
+impl ZHashable for u32 {
+  type ZHashKey = ();
+  fn zhash_key(_zbox: ZHashBox<'_, u32>) -> Self::ZHashKey {}
+  fn zhash_fn(_key: Self::ZHashKey, point: &Point<Self, 2>) -> u64 {
+    zhash_pair(*point.x_coord(), *point.y_coord())
+  }
+}
+
+pub fn zunhash_pair(w: u64) -> (u32, u32) {
+  (zunhash_u32(w), zunhash_u32(w >> 1))
+}
+
+fn zunhash_u32(w: u64) -> u32 {
+  let w = w & 0x5555555555555555;
+  let w = (w | w >> 1) & 0x3333333333333333;
+  let w = (w | w >> 2) & 0x0F0F0F0F0F0F0F0F;
+  let w = (w | w >> 4) & 0x00FF00FF00FF00FF;
+  let w = (w | w >> 8) & 0x0000FFFF0000FFFF;
+  let w = (w | w >> 16) & 0x00000000FFFFFFFF;
+  w as u32
+}
+
+pub fn zhash_pair(a: u32, b: u32) -> u64 {
+  zhash_u32(a) | zhash_u32(b) << 1
+}
+
+fn zhash_u32(w: u32) -> u64 {
+  let w = w as u64; // & 0x00000000FFFFFFFF;
+  let w = (w | w << 16) & 0x0000FFFF0000FFFF;
+  let w = (w | w << 8) & 0x00FF00FF00FF00FF;
+  let w = (w | w << 4) & 0x0F0F0F0F0F0F0F0F;
+  let w = (w | w << 2) & 0x3333333333333333;
+  (w | w << 1) & 0x5555555555555555
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  use proptest::prelude::*;
+
+  proptest! {
+    #[test]
+    fn hash_unhash(a in any::<u32>(), b in any::<u32>()) {
+      prop_assert_eq!(zunhash_pair(zhash_pair(a,b)), (a,b))
+
+    }
+  }
+}

--- a/src/algorithms/zhash.rs
+++ b/src/algorithms/zhash.rs
@@ -9,10 +9,10 @@ use crate::data::Point;
 
 #[derive(Debug)]
 pub struct ZHashBox<'a, T> {
-  min_x: &'a T,
-  max_x: &'a T,
-  min_y: &'a T,
-  max_y: &'a T,
+  pub min_x: &'a T,
+  pub max_x: &'a T,
+  pub min_y: &'a T,
+  pub max_y: &'a T,
 }
 impl<'a, T> Copy for ZHashBox<'a, T> {}
 
@@ -28,7 +28,7 @@ impl<'a, T> Clone for ZHashBox<'a, T> {
 }
 
 pub trait ZHashable: Sized {
-  type ZHashKey;
+  type ZHashKey: Copy;
   fn zhash_key(zbox: ZHashBox<'_, Self>) -> Self::ZHashKey;
   fn zhash_fn(key: Self::ZHashKey, point: &Point<Self, 2>) -> u64;
 }
@@ -75,8 +75,8 @@ impl ZHashable for i8 {
     let (min_x, min_y) = key;
     let x = (point.x_coord().wrapping_sub(min_x) as u8) as u32;
     let y = (point.y_coord().wrapping_sub(min_y) as u8) as u32;
-    dbg!(point.x_coord(), min_x, x);
-    dbg!(point.y_coord(), min_y, y);
+    // dbg!(point.x_coord(), min_x, x);
+    // dbg!(point.y_coord(), min_y, y);
     zhash_pair(x, y)
   }
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,21 +1,9 @@
-use array_init::array_init;
-use num_traits::CheckedMul;
 use num_traits::Signed;
 use std::cmp::Ordering;
-use std::ops::BitXor;
-use std::ops::Index;
 use std::ops::Mul;
-use std::ops::Neg;
 use std::ops::Sub;
 
 use crate::Extended;
-
-pub fn raw_arr_sub<T, const N: usize>(lhs: &[T; N], rhs: &[T; N]) -> [T; N]
-where
-  T: Sub<Output = T> + Clone,
-{
-  array_init(|i| (lhs.index(i).clone() - rhs.index(i).clone()))
-}
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone)]
 pub enum Orientation {
@@ -175,9 +163,9 @@ impl Orientation {
 //   }
 // }
 
-pub fn extended_orientation_i64(p: &[i64; 2], q: &[i64; 2], r: &[i64; 2]) -> Ordering {
-  crate::Extended::cmp_slope(p, q, r)
-}
+// pub fn extended_orientation_i64(p: &[i64; 2], q: &[i64; 2], r: &[i64; 2]) -> Ordering {
+//   crate::Extended::cmp_slope(p, q, r)
+// }
 
 // pub fn turn_i64(p: &[i64; 2], q: &[i64; 2], r: &[i64; 2]) -> Orientation {
 //   raw_arr_turn_2(p, q, r)

--- a/src/data/intersection_set.rs
+++ b/src/data/intersection_set.rs
@@ -3,11 +3,10 @@ use crate::data::PointId;
 use crate::utils::SparseIndex;
 use crate::utils::SparseVec;
 
-use rand::seq::SliceRandom;
 use rand::Rng;
 use std::ops::{Index, IndexMut};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[non_exhaustive]
 pub struct IndexIntersection {
   pub min: IndexEdge,
@@ -75,6 +74,8 @@ impl IndexIntersectionSet {
   fn remove(&mut self, idx: SparseIndex) {
     let isect = self.by_idx.remove(idx);
 
+    // eprintln!("Removing intersection: {:?}", isect);
+
     for &edge in &[isect.edge0, isect.edge1] {
       match edge.prev {
         Some(prev) => self.by_idx[prev][IndexEdge::from(edge)].next = edge.next,
@@ -107,13 +108,8 @@ impl IndexIntersectionSet {
     ))
   }
 
-  pub fn to_vec(&self) -> Vec<IndexIntersection> {
-    self
-      .by_idx
-      .to_vec()
-      .into_iter()
-      .map(|isect| isect.into())
-      .collect()
+  pub fn iter(&self) -> impl Iterator<Item = IndexIntersection> + '_ {
+    self.by_idx.iter().map(|&isect| isect.into())
   }
 }
 

--- a/src/data/point.rs
+++ b/src/data/point.rs
@@ -2,7 +2,7 @@ use array_init::{array_init, try_array_init};
 use num_bigint::BigInt;
 use num_rational::BigRational;
 use num_traits::*;
-use ordered_float::{FloatIsNan, NotNan, OrderedFloat};
+use ordered_float::{FloatIsNan, NotNan};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 use std::cmp::Ordering;
@@ -267,18 +267,7 @@ pub mod tests {
   use crate::testing::*;
   use crate::Orientation::*;
 
-  use ordered_float::Float;
-  use ordered_float::NotNan;
-  use std::convert::TryInto;
-  use std::fmt::Debug;
-  use std::ops::IndexMut;
-
-  use proptest::array::*;
-  use proptest::collection::*;
-  use proptest::num;
   use proptest::prelude::*;
-  use proptest::strategy::*;
-  use proptest::test_runner::*;
 
   proptest! {
     #[test]

--- a/src/data/point.rs
+++ b/src/data/point.rs
@@ -264,6 +264,7 @@ mod sub;
 #[cfg(test)]
 pub mod tests {
   use super::*;
+  use crate::testing::*;
   use crate::Orientation::*;
 
   use ordered_float::Float;
@@ -278,124 +279,6 @@ pub mod tests {
   use proptest::prelude::*;
   use proptest::strategy::*;
   use proptest::test_runner::*;
-
-  pub struct PointValueTree<T, const N: usize> {
-    point: Point<T, N>,
-    shrink: usize,
-    prev_shrink: Option<usize>,
-  }
-  impl<T, const N: usize> ValueTree for PointValueTree<T, N>
-  where
-    T: ValueTree,
-  {
-    type Value = Point<<T as ValueTree>::Value, N>;
-    fn current(&self) -> Point<T::Value, N> {
-      Point {
-        array: array_init(|i| self.point.array.index(i).current()),
-      }
-    }
-    fn simplify(&mut self) -> bool {
-      for ix in self.shrink..N {
-        if !self.point.array.index_mut(ix).simplify() {
-          self.shrink = ix + 1;
-        } else {
-          self.prev_shrink = Some(ix);
-          return true;
-        }
-      }
-      false
-    }
-    fn complicate(&mut self) -> bool {
-      match self.prev_shrink {
-        None => false,
-        Some(ix) => {
-          if self.point.array.index_mut(ix).complicate() {
-            true
-          } else {
-            self.prev_shrink = None;
-            false
-          }
-        }
-      }
-    }
-  }
-
-  impl<T, const N: usize> Strategy for Point<T, N>
-  where
-    T: Clone + Debug + Strategy,
-  {
-    type Tree = PointValueTree<T::Tree, N>;
-    type Value = Point<<T as Strategy>::Value, N>;
-    fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-      let tree = PointValueTree {
-        point: Point {
-          array: try_array_init(|i| self.array.index(i).new_tree(runner))?,
-        },
-        shrink: 0,
-        prev_shrink: None,
-      };
-
-      Ok(tree)
-    }
-  }
-
-  impl<const N: usize> Arbitrary for Point<f64, N> {
-    type Strategy = Point<num::f64::Any, N>;
-    type Parameters = ();
-    fn arbitrary_with(_params: ()) -> Self::Strategy {
-      use num::f64::*;
-      let strat = POSITIVE | NEGATIVE | NORMAL | SUBNORMAL | ZERO;
-      Point {
-        array: array_init(|_| strat),
-      }
-    }
-  }
-
-  impl<const N: usize> Arbitrary for Point<isize, N> {
-    type Strategy = Point<num::isize::Any, N>;
-    type Parameters = ();
-    fn arbitrary_with(_params: ()) -> Self::Strategy {
-      Point {
-        array: array_init(|_| any::<isize>()),
-      }
-    }
-  }
-
-  impl<const N: usize> Arbitrary for Point<i64, N> {
-    type Strategy = Point<num::i64::Any, N>;
-    type Parameters = ();
-    fn arbitrary_with(_params: ()) -> Self::Strategy {
-      Point {
-        array: array_init(|_| any::<i64>()),
-      }
-    }
-  }
-
-  impl<const N: usize> Arbitrary for Point<i8, N> {
-    type Strategy = Point<num::i8::Any, N>;
-    type Parameters = ();
-    fn arbitrary_with(_params: ()) -> Self::Strategy {
-      Point {
-        array: array_init(|_| any::<i8>()),
-      }
-    }
-  }
-
-  pub fn any_nn<const N: usize>() -> impl Strategy<Value = Point<NotNan<f64>, N>> {
-    any::<Point<f64, N>>().prop_filter_map("Check for NaN", |pt| pt.try_into().ok())
-  }
-
-  pub fn any_r<const N: usize>() -> impl Strategy<Value = Point<BigInt, N>> {
-    any::<Point<isize, N>>().prop_map(|pt| pt.cast(BigInt::from))
-  }
-
-  pub fn any_64<const N: usize>() -> impl Strategy<Value = Point<i64, N>> {
-    any::<Point<i64, N>>()
-  }
-
-  pub fn any_8<const N: usize>() -> impl Strategy<Value = Point<i8, N>> {
-    any::<Point<i8, N>>()
-  }
 
   proptest! {
     #[test]

--- a/src/data/polygon.rs
+++ b/src/data/polygon.rs
@@ -1,22 +1,12 @@
 // use claim::debug_assert_ok;
 use num_rational::BigRational;
 use num_traits::*;
-use ordered_float::{FloatIsNan, NotNan, OrderedFloat};
-use std::borrow::Borrow;
-use std::iter::ExactSizeIterator;
-use std::iter::FromIterator;
 use std::iter::Sum;
 use std::ops::*;
 
 use crate::array::Orientation;
-use crate::data::DirectedEdge;
-use crate::data::Point;
-use crate::data::PointLocation;
-use crate::data::TriangleView;
-use crate::data::Vector;
-use crate::Error;
-use crate::Extended;
-use crate::PolygonScalar;
+use crate::data::{DirectedEdge, Point, PointLocation, TriangleView, Vector};
+use crate::{Error, PolygonScalar};
 
 mod iter;
 pub use iter::*;
@@ -589,7 +579,6 @@ impl Position {
 #[cfg(test)]
 pub mod tests {
   use super::*;
-  use crate::data::point::tests::*;
 
   use proptest::prelude::*;
 

--- a/src/data/polygon/convex.rs
+++ b/src/data/polygon/convex.rs
@@ -59,7 +59,7 @@ where
     }
     let p1 = poly.point(vertices[lower]);
     let p2 = poly.point(vertices[upper]);
-    let triangle = TriangleView::new([p0, p1, p2]);
+    let triangle = TriangleView::new_unchecked([p0, p1, p2]);
     triangle.locate(pt)
   }
 

--- a/src/data/polygon/convex.rs
+++ b/src/data/polygon/convex.rs
@@ -9,7 +9,6 @@ use std::collections::BTreeSet;
 use std::ops::*;
 
 use crate::array::Orientation;
-use crate::data;
 use crate::data::Point;
 use crate::data::PointLocation;
 use crate::data::TriangleView;
@@ -246,14 +245,8 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::Orientation::*;
-  use crate::*;
 
   use proptest::prelude::*;
-  use proptest::strategy::*;
-  use proptest::test_runner::*;
-
-  use ordered_float::NotNan;
 
   impl Arbitrary for PolygonConvex<BigRational> {
     type Strategy = Just<PolygonConvex<BigRational>>;

--- a/src/data/polygon/iter.rs
+++ b/src/data/polygon/iter.rs
@@ -1,16 +1,8 @@
 // use claim::debug_assert_ok;
-use std::iter::Zip;
-use std::ops::*;
 
-use crate::data::line_segment::*;
 use crate::data::Cursor;
 use crate::data::DirectedEdge;
 use crate::data::Point;
-use crate::data::PointId;
-use crate::data::Polygon;
-use crate::data::Position;
-use crate::data::PositionId;
-use crate::data::RingId;
 
 pub struct Iter<'a, T: 'a> {
   pub(crate) iter: std::slice::Iter<'a, Point<T, 2>>,

--- a/src/data/triangle.rs
+++ b/src/data/triangle.rs
@@ -2,19 +2,32 @@ use super::{Point, PointLocation};
 use crate::{Error, Orientation, PolygonScalar, PolygonScalarRef};
 use claim::debug_assert_ok;
 use num_traits::*;
+use rand::distributions::uniform::SampleUniform;
+use rand::Rng;
 
 // FIXME: Support n-dimensional triangles?
+#[derive(Debug, Clone)]
 pub struct Triangle<T>([Point<T, 2>; 3]);
 
 impl<T> Triangle<T>
 where
   T: PolygonScalar,
-  for<'a> &'a T: PolygonScalarRef<&'a T, T>,
 {
-  pub fn new(pts: [Point<T, 2>; 3]) -> Triangle<T> {
+  pub fn new(pts: [Point<T, 2>; 3]) -> Result<Triangle<T>, Error> {
     let triangle = Triangle(pts);
-    debug_assert_ok!(triangle.validate());
-    triangle
+    triangle.validate()?;
+    Ok(triangle)
+  }
+
+  pub fn new_ccw(mut pts: [Point<T, 2>; 3]) -> Triangle<T> {
+    match Orientation::new(&pts[0], &pts[1], &pts[2]) {
+      Orientation::CounterClockWise => Triangle(pts),
+      Orientation::ClockWise => {
+        pts.swap(0, 2);
+        Triangle(pts)
+      }
+      Orientation::CoLinear => panic!("Cannot orient colinear points."),
+    }
   }
 
   pub fn validate(&self) -> Result<(), Error> {
@@ -39,10 +52,18 @@ where
   // for<'x> &'x T: PolygonScalarRef<&'x T, T>,
 {
   // O(1)
-  pub fn new(pts: [&'a Point<T, 2>; 3]) -> TriangleView<'a, T> {
+  pub fn new(pts: [&'a Point<T, 2>; 3]) -> Result<TriangleView<'a, T>, Error> {
     let triangle = TriangleView(pts);
-    debug_assert_ok!(triangle.validate());
-    triangle
+    triangle.validate()?;
+    Ok(triangle)
+  }
+
+  pub fn new_ccw(pts: [&'a Point<T, 2>; 3]) -> TriangleView<'a, T> {
+    match Orientation::new(&pts[0], &pts[1], &pts[2]) {
+      Orientation::CounterClockWise => TriangleView(pts),
+      Orientation::ClockWise => TriangleView([&pts[2], &pts[1], &pts[0]]),
+      Orientation::CoLinear => panic!("Cannot orient colinear points."),
+    }
   }
 
   pub fn new_unchecked(pts: [&'a Point<T, 2>; 3]) -> TriangleView<'a, T> {
@@ -106,4 +127,56 @@ where
     // x2*y3 - x3*y2 +
     // x3*y1 - x1*y3
   }
+
+  pub fn bounding_box(&self) -> (Point<T, 2>, Point<T, 2>) {
+    let min_x = self.0[0]
+      .x_coord()
+      .min(self.0[1].x_coord())
+      .min(self.0[1].x_coord())
+      .clone();
+    let max_x = self.0[0]
+      .x_coord()
+      .max(self.0[1].x_coord())
+      .max(self.0[1].x_coord())
+      .clone();
+    let min_y = self.0[0]
+      .y_coord()
+      .min(self.0[1].y_coord())
+      .min(self.0[1].y_coord())
+      .clone();
+    let max_y = self.0[0]
+      .y_coord()
+      .max(self.0[1].y_coord())
+      .max(self.0[1].y_coord())
+      .clone();
+    (Point::new([min_x, min_y]), Point::new([max_x, max_y]))
+  }
+
+  pub fn rejection_sampling<R>(&self, rng: &mut R) -> Point<T, 2>
+  where
+    R: Rng + ?Sized,
+    T: SampleUniform,
+  {
+    let (min, max) = self.bounding_box();
+    loop {
+      let [min_x, min_y] = min.array.clone();
+      let [max_x, max_y] = max.array.clone();
+      let x = rng.gen_range(min_x..=max_x);
+      let y = rng.gen_range(min_y..=max_y);
+      let pt = Point::new([x, y]);
+      if self.locate(&pt) != PointLocation::Outside {
+        return pt;
+      }
+    }
+  }
+
+  //   sampleTriangle :: (RandomGen g, Random r, Fractional r, Ord r) => Triangle 2 p r -> Rand g (Point 2 r)
+  // sampleTriangle (Triangle v1 v2 v3) = do
+  //   a' <- getRandomR (0, 1)
+  //   b' <- getRandomR (0, 1)
+  //   let (a, b) = if a' + b' > 1 then (1 - a', 1 - b') else (a', b')
+  //   return $ v1^.core .+^ a*^u .+^ b*^v
+  //   where
+  //     u = v2^.core .-. v1^.core
+  //     v = v3^.core .-. v1^.core
 }

--- a/src/data/triangle.rs
+++ b/src/data/triangle.rs
@@ -132,22 +132,22 @@ where
     let min_x = self.0[0]
       .x_coord()
       .min(self.0[1].x_coord())
-      .min(self.0[1].x_coord())
+      .min(self.0[2].x_coord())
       .clone();
     let max_x = self.0[0]
       .x_coord()
       .max(self.0[1].x_coord())
-      .max(self.0[1].x_coord())
+      .max(self.0[2].x_coord())
       .clone();
     let min_y = self.0[0]
       .y_coord()
       .min(self.0[1].y_coord())
-      .min(self.0[1].y_coord())
+      .min(self.0[2].y_coord())
       .clone();
     let max_y = self.0[0]
       .y_coord()
       .max(self.0[1].y_coord())
-      .max(self.0[1].y_coord())
+      .max(self.0[2].y_coord())
       .clone();
     (Point::new([min_x, min_y]), Point::new([max_x, max_y]))
   }
@@ -170,7 +170,7 @@ where
     }
   }
 
-  //   sampleTriangle :: (RandomGen g, Random r, Fractional r, Ord r) => Triangle 2 p r -> Rand g (Point 2 r)
+  // sampleTriangle :: (RandomGen g, Random r, Fractional r, Ord r) => Triangle 2 p r -> Rand g (Point 2 r)
   // sampleTriangle (Triangle v1 v2 v3) = do
   //   a' <- getRandomR (0, 1)
   //   b' <- getRandomR (0, 1)

--- a/src/data/triangle.rs
+++ b/src/data/triangle.rs
@@ -1,6 +1,7 @@
 use super::{Point, PointLocation};
 use crate::{Error, Orientation, PolygonScalar, PolygonScalarRef};
 use claim::debug_assert_ok;
+use num_traits::*;
 use std::ops::*;
 
 // FIXME: Support n-dimensional triangles?
@@ -70,5 +71,32 @@ where
     } else {
       PointLocation::Inside
     }
+  }
+
+  pub fn signed_area<F>(&self) -> F
+  where
+    T: PolygonScalar + Into<F>,
+    F: NumOps<F, F> + FromPrimitive + Clone,
+  {
+    self.signed_area_2x::<F>() / F::from_usize(2).unwrap()
+  }
+
+  pub fn signed_area_2x<F>(&self) -> F
+  where
+    T: PolygonScalar + Into<F>,
+    F: NumOps<F, F> + Clone,
+  {
+    let [a, b, c] = self.0;
+    let ax = a.x_coord().clone().into();
+    let ay = a.y_coord().clone().into();
+    let bx = b.x_coord().clone().into();
+    let by = b.y_coord().clone().into();
+    let cx = c.x_coord().clone().into();
+    let cy = c.y_coord().clone().into();
+    ax.clone() * by.clone() - bx.clone() * ay.clone() + bx * cy.clone() - cx.clone() * by + cx * ay
+      - ax * cy
+    // x1*y2 - x2*y1 +
+    // x2*y3 - x3*y2 +
+    // x3*y1 - x1*y3
   }
 }

--- a/src/data/triangle.rs
+++ b/src/data/triangle.rs
@@ -2,7 +2,6 @@ use super::{Point, PointLocation};
 use crate::{Error, Orientation, PolygonScalar, PolygonScalarRef};
 use claim::debug_assert_ok;
 use num_traits::*;
-use std::ops::*;
 
 // FIXME: Support n-dimensional triangles?
 pub struct Triangle<T>([Point<T, 2>; 3]);

--- a/src/data/triangle.rs
+++ b/src/data/triangle.rs
@@ -46,14 +46,22 @@ where
     triangle
   }
 
+  pub fn new_unchecked(pts: [&'a Point<T, 2>; 3]) -> TriangleView<'a, T> {
+    TriangleView(pts)
+  }
+
   // O(1)
   pub fn validate(&self) -> Result<(), Error> {
-    let arr = &self.0;
-    if arr.index(0).orientation(&arr[1], &arr[2]) != Orientation::CounterClockWise {
+    if self.orientation() != Orientation::CounterClockWise {
       Err(Error::ClockWiseViolation)
     } else {
       Ok(())
     }
+  }
+
+  pub fn orientation(&self) -> Orientation {
+    let arr = &self.0;
+    Orientation::new(&arr[0], &arr[1], &arr[2])
   }
 
   // O(1)

--- a/src/data/vector.rs
+++ b/src/data/vector.rs
@@ -1,8 +1,6 @@
 use array_init::{array_init, try_array_init};
 use num_rational::BigRational;
-use num_traits::identities::One;
 use num_traits::identities::Zero;
-use num_traits::NumRef;
 use num_traits::{NumOps, Signed};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,13 @@ pub enum Error {
   ConvexViolation,
   ClockWiseViolation,
 }
+
+impl std::fmt::Display for Error {
+  fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+    todo!()
+  }
+}
+
 pub trait PolygonScalar<T = Self, Output = Self>:
   PolygonScalarRef<T, Output>
   + AddAssign<Output>
@@ -189,3 +196,6 @@ arbitrary_precision!(num_rational::BigRational);
 // arbitrary_precision!(ordered_float::OrderedFloat<f64>);
 arbitrary_precision!(ordered_float::NotNan<f32>);
 arbitrary_precision!(ordered_float::NotNan<f64>);
+
+#[cfg(test)]
+pub mod testing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use std::iter::Sum;
 use std::ops::*;
 
 pub mod algorithms;
-pub mod array;
+mod array;
 pub mod data;
 mod intersection;
 mod matrix;
@@ -33,8 +33,14 @@ pub enum Error {
 }
 
 impl std::fmt::Display for Error {
-  fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-    todo!()
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+    match self {
+      Error::InsufficientVertices => write!(f, "Insufficient vertices"),
+      Error::SelfIntersections => write!(f, "Self intersections"),
+      Error::DuplicatePoints => write!(f, "Duplicate points"),
+      Error::ConvexViolation => write!(f, "Convex violation"),
+      Error::ClockWiseViolation => write!(f, "Clockwise violation"),
+    }
   }
 }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -170,7 +170,7 @@ where
     let mut points = Vec::with_capacity(n);
     let mut set = BTreeSet::new();
     let mut actual = Vec::new();
-    for _ in 0..n {
+    while actual.len() < n {
       let pt = Point::new([self.0.clone(), self.0.clone()]).new_tree(runner)?;
       let current = pt.current();
       if set.insert(current.clone()) {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,320 @@
+// This module contains strategies and shrinkers for:
+//  * points
+//  * polygons
+// A Strategy is a way to generate a shrinkable value.
+use crate::data::point::tests::*;
+use crate::data::{Point, PointId, Polygon};
+use crate::PolygonScalar;
+
+use array_init::{array_init, try_array_init};
+use core::ops::Range;
+use num_bigint::BigInt;
+use ordered_float::NotNan;
+use proptest::array::*;
+use proptest::collection::*;
+use proptest::num;
+use proptest::num::f64::*;
+use proptest::prelude::*;
+use proptest::strategy::*;
+use proptest::test_runner::*;
+use std::convert::TryInto;
+use std::fmt::Debug;
+use std::ops::Index;
+use std::ops::IndexMut;
+
+///////////////////////////////////////////////////////////////////////////////
+// Shrinkable polygons
+
+// Shrinking a polygon.
+// 1. Cut off ears.
+// 2. Simplify points.
+pub struct ShrinkablePolygon<T: ValueTree> {
+  points: Vec<ShrinkablePoint<T, 2>>,
+  cut: Option<PointId>,
+  uncut: Vec<PointId>,
+  shrink: usize,
+  done: bool,
+}
+
+impl<T: ValueTree> ShrinkablePolygon<T>
+where
+  <T as ValueTree>::Value: Clone + PolygonScalar,
+{
+  fn new(points: Vec<ShrinkablePoint<T, 2>>) -> Self {
+    ShrinkablePolygon {
+      points: points,
+      cut: None,
+      uncut: Vec::new(),
+      shrink: 0,
+      done: false,
+    }
+  }
+
+  fn polygon(&self) -> Polygon<<T as ValueTree>::Value> {
+    Polygon::new_unchecked(self.points.iter().map(|pt| pt.current()).collect())
+  }
+}
+
+impl<T: ValueTree> ValueTree for ShrinkablePolygon<T>
+where
+  <T as ValueTree>::Value: Clone + PolygonScalar,
+{
+  type Value = Polygon<<T as ValueTree>::Value>;
+
+  fn current(&self) -> Self::Value {
+    if self.done {
+      return self.polygon();
+    }
+    let mut poly = self.polygon();
+    if let Some(cut) = self.cut {
+      poly.rings[0].remove(cut.usize());
+    }
+    return poly;
+  }
+
+  // Reduce the complexity and return 'true' if something changed.
+  // Return 'false' if the complexity cannot be reduced.
+  fn simplify(&mut self) -> bool {
+    if self.done {
+      // eprintln!("Shrink done");
+      return false;
+    }
+
+    // If we previously cut an ear and the tests are still failing, make the cut permanent.
+    if let Some(cut) = self.cut {
+      // eprintln!("Shrink cut {:?}", cut);
+      self.points.remove(cut.usize());
+      self.cut = None;
+      self.uncut.clear();
+    }
+
+    // Look for more ears to cut.
+    for pt in self.polygon().iter_boundary() {
+      if !self.uncut.contains(&pt.point_id()) && pt.is_ear() {
+        // eprintln!("Shrink ear: {:?}", pt.point_id());
+        self.cut = Some(pt.point_id());
+        return true;
+      }
+    }
+
+    // No more ears can be cut. Let's try simplifying points:
+    // eprintln!("Shrinking point: {}", self.shrink);
+    while self.shrink < self.points.len() && !self.points[self.shrink].simplify() {
+      self.shrink += 1;
+      // eprintln!("Shrink next point: {}", self.shrink);
+    }
+    if self.shrink < self.points.len() {
+      while self.polygon().validate().is_err() {
+        // eprintln!("Bad point shrink. Undo: {}", self.shrink);
+        if !self.points[self.shrink].complicate() {
+          // eprintln!("Cannot undo. Abort");
+          self.done = true;
+          return true;
+        }
+      }
+      return true;
+    } else {
+      self.done = true;
+      return false;
+    }
+  }
+
+  // The value has been shrunk so much that the test-cases no longer fail.
+  // Undo the last shrink action and find another way to shrink the value.
+  fn complicate(&mut self) -> bool {
+    if self.done {
+      return false;
+    }
+
+    if let Some(cut) = self.cut {
+      // eprintln!("Undo cut");
+      self.uncut.push(cut);
+      self.cut = None;
+      return true;
+    }
+
+    if self.shrink < self.points.len() {
+      // eprintln!("Undo shrink");
+      if !self.points[self.shrink].complicate() {
+        self.shrink += 1;
+      } else {
+        while self.polygon().validate().is_err() {
+          // eprintln!("Bad point unshrink. Undo: {}", self.shrink);
+          if !self.points[self.shrink].complicate() {
+            // eprintln!("Cannot undo. Abort");
+            self.done = true;
+            return true;
+          }
+        }
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Polygon strategy
+
+#[derive(Debug, Clone)]
+pub struct PolygonStrat<T>(T, Range<usize>);
+
+impl<T> Strategy for PolygonStrat<T>
+where
+  T: Clone + std::fmt::Debug + Strategy,
+  T::Value: Clone + PolygonScalar,
+  T::Tree: Clone,
+{
+  type Tree = ShrinkablePolygon<T::Tree>;
+  type Value = Polygon<T::Value>;
+  fn new_tree(&self, runner: &mut TestRunner) -> Result<Self::Tree, Reason> {
+    let n = runner.rng().gen_range(self.1.clone()).max(3);
+    let mut points = Vec::with_capacity(n);
+    for _ in 0..n {
+      points.push(Point::new([self.0.clone(), self.0.clone()]).new_tree(runner)?)
+    }
+    let actual = points.iter().map(|pt| pt.current()).collect();
+    let poly =
+      crate::algorithms::two_opt_moves(actual, runner.rng()).map_err(|err| err.to_string())?;
+
+    // FIXME: Super ugly:
+    let mut new_points = Vec::new();
+    for &pid in poly.rings[0].iter() {
+      new_points.push(points[pid.usize()].clone());
+    }
+
+    Ok(ShrinkablePolygon::new(new_points))
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Arbitrary polygons
+
+impl<T: Arbitrary> Arbitrary for Polygon<T>
+where
+  T::Strategy: Clone,
+  <<T as Arbitrary>::Strategy as Strategy>::Tree: Clone,
+  T: PolygonScalar,
+{
+  type Strategy = PolygonStrat<T::Strategy>;
+  type Parameters = (Range<usize>, T::Parameters);
+  fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {
+    let (size_range, t_params) = params;
+    if size_range.is_empty() {
+      PolygonStrat(T::arbitrary_with(t_params), 3..10)
+    } else {
+      PolygonStrat(T::arbitrary_with(t_params), size_range)
+    }
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Shrinkable point
+
+#[derive(Clone)]
+pub struct ShrinkablePoint<T, const N: usize> {
+  point: Point<T, N>,
+  shrink: usize,
+  prev_shrink: Option<usize>,
+}
+impl<T, const N: usize> ValueTree for ShrinkablePoint<T, N>
+where
+  T: ValueTree,
+{
+  type Value = Point<<T as ValueTree>::Value, N>;
+  fn current(&self) -> Point<T::Value, N> {
+    Point {
+      array: array_init(|i| self.point.array.index(i).current()),
+    }
+  }
+  fn simplify(&mut self) -> bool {
+    for ix in self.shrink..N {
+      if !self.point.array.index_mut(ix).simplify() {
+        self.shrink = ix + 1;
+      } else {
+        self.prev_shrink = Some(ix);
+        return true;
+      }
+    }
+    false
+  }
+  fn complicate(&mut self) -> bool {
+    match self.prev_shrink {
+      None => false,
+      Some(ix) => {
+        if self.point.array.index_mut(ix).complicate() {
+          true
+        } else {
+          self.prev_shrink = None;
+          false
+        }
+      }
+    }
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Point strategy
+
+impl<T, const N: usize> Strategy for Point<T, N>
+where
+  T: Clone + Debug + Strategy,
+{
+  type Tree = ShrinkablePoint<T::Tree, N>;
+  type Value = Point<<T as Strategy>::Value, N>;
+  fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+    let tree = ShrinkablePoint {
+      point: Point {
+        array: try_array_init(|i| self.array.index(i).new_tree(runner))?,
+      },
+      shrink: 0,
+      prev_shrink: None,
+    };
+
+    Ok(tree)
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Arbitrary point
+
+impl<T: Arbitrary, const N: usize> Arbitrary for Point<T, N>
+where
+  T::Strategy: Clone,
+  T::Parameters: Clone,
+  T: Clone,
+{
+  type Strategy = Point<T::Strategy, N>;
+  type Parameters = T::Parameters;
+  fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {
+    Point {
+      array: array_init(|_| T::arbitrary_with(params.clone())),
+    }
+  }
+}
+
+// FIXME: Move this impl to 'ordered_float' crate.
+// impl Arbitrary for NotNan<f64> {
+//   type Strategy = num::f64::Any;
+//   type Parameters = ();
+//   fn arbitrary_with(_params: ()) -> Self::Strategy {
+//     POSITIVE | NEGATIVE | NORMAL | SUBNORMAL | ZERO;
+//   }
+// }
+
+pub fn any_nn<const N: usize>() -> impl Strategy<Value = Point<NotNan<f64>, N>> {
+  any::<Point<f64, N>>().prop_filter_map("Check for NaN", |pt| pt.try_into().ok())
+}
+
+pub fn any_r<const N: usize>() -> impl Strategy<Value = Point<BigInt, N>> {
+  any::<Point<isize, N>>().prop_map(|pt| pt.cast(BigInt::from))
+}
+
+pub fn any_64<const N: usize>() -> impl Strategy<Value = Point<i64, N>> {
+  any::<Point<i64, N>>()
+}
+
+pub fn any_8<const N: usize>() -> impl Strategy<Value = Point<i8, N>> {
+  any::<Point<i8, N>>()
+}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -2,7 +2,7 @@
 //  * points
 //  * polygons
 // A Strategy is a way to generate a shrinkable value.
-use crate::data::{Point, PointId, Polygon};
+use crate::data::{Point, PointId, Polygon, Triangle};
 use crate::PolygonScalar;
 
 use array_init::{array_init, try_array_init};
@@ -325,3 +325,33 @@ pub fn any_64<const N: usize>() -> impl Strategy<Value = Point<i64, N>> {
 pub fn any_8<const N: usize>() -> impl Strategy<Value = Point<i8, N>> {
   any::<Point<i8, N>>()
 }
+
+///////////////////////////////////////////////////////////////////////////////
+// Arbitrary triangle
+
+pub fn any_triangle<T>() -> impl Strategy<Value = Triangle<T>>
+where
+  T: Arbitrary + Clone + PolygonScalar,
+  <T as Arbitrary>::Strategy: Clone,
+  <T as Arbitrary>::Parameters: Clone,
+{
+  any::<[Point<T, 2>; 3]>().prop_filter_map("Ensure CCW", |pts| Triangle::new(pts).ok())
+}
+
+// impl<T: Arbitrary> Arbitrary for Triangle<T>
+// where
+//   T::Strategy: Clone,
+//   T::Parameters: Clone,
+//   T: Clone,
+// {
+//   type Strategy = [T::Strategy; 3];
+//   type Parameters = T::Parameters;
+//   fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {
+//     let p1 = T::arbitrary_with(params);
+//     let p2 = T::arbitrary_with(params);
+//     let p3 = T::arbitrary_with(params);
+//     Point {
+//       array: array_init(|_| T::arbitrary_with(params.clone())),
+//     }
+//   }
+// }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,4 @@
-use num_traits::NumOps;
-use rand::seq::SliceRandom;
 use rand::Rng;
-use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 
 pub type SparseIndex = usize;
@@ -47,12 +44,8 @@ impl<T: Copy + Default> SparseVec<T> {
     self.dense.random(rng)
   }
 
-  pub fn to_vec(&self) -> Vec<T> {
-    let mut out = Vec::new();
-    for &idx in self.dense.dense.iter() {
-      out.push(self.arr[idx])
-    }
-    out
+  pub fn iter(&self) -> impl Iterator<Item = &T> + '_ {
+    self.dense.iter().map(move |idx| self.arr.index(idx))
   }
 }
 
@@ -113,5 +106,9 @@ impl DenseCollection {
     }
     let idx = rng.gen_range(0..self.dense.len());
     Some(self.dense[idx])
+  }
+
+  fn iter(&self) -> impl Iterator<Item = Sparse> + '_ {
+    self.dense.iter().copied()
   }
 }

--- a/tests/two_opt.rs
+++ b/tests/two_opt.rs
@@ -54,7 +54,10 @@ mod two_opt {
       Point::new([0, 1]),
       Point::new([0, 1]),
     ];
-    dbg!(two_opt_moves(pts, &mut rng)?);
+    assert_eq!(
+      two_opt_moves(pts, &mut rng).err(),
+      Some(Error::DuplicatePoints)
+    );
     Ok(())
   }
 

--- a/tests/two_opt.rs
+++ b/tests/two_opt.rs
@@ -85,7 +85,7 @@ mod two_opt {
       Point::new([0, 1]),
       Point::new([2, 1]),
     ];
-    dbg!(two_opt_moves(pts, &mut rng)?);
+    two_opt_moves(pts, &mut rng)?;
     Ok(())
   }
 
@@ -99,7 +99,7 @@ mod two_opt {
       Point::new([0.0, 1.0]).into(),
       Point::new([2.0, 1.0]).into(),
     ];
-    dbg!(two_opt_moves(pts, &mut rng)?);
+    two_opt_moves(pts, &mut rng)?;
     Ok(())
   }
 }


### PR DESCRIPTION
As far as I know, ear-clipping with z-order hashing is the most performant triangulation method known.

Earclip.js/FIST tries hard to always generate reasonable output even if the input is garbled. Not sure if I want to duplicate that behavior. I'm fine with only accepting valid input. Input sanitation can be done separately.