### PR TITLE
Configurable lean direction for HalfLineSoS's

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod orientation;
 mod transformation;
 mod utils;
 
-pub use orientation::Orientation;
+pub use orientation::{Orientation, SoS};
 
 pub use intersection::Intersects;
 

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -131,6 +131,14 @@ impl Orientation {
     }
   }
 
+  pub fn sos(self, other: SoS) -> SoS {
+    match self {
+      CounterClockWise => SoS::CounterClockWise,
+      ClockWise => SoS::ClockWise,
+      CoLinear => other,
+    }
+  }
+
   // pub fn around_origin<T>(q: &[T; 2], r: &[T; 2]) -> Orientation
   // where
   //   T: Ord + Mul<Output = T> + Clone + Extended,


### PR DESCRIPTION
Consider the following case where a ray points to the end of an edge between 'a' and 'b':
```
  a---b
  ^
  |
  |
 ray
```
SoS is a technique for avoiding intersections through vertices (because then you don't have to deal with grazing collisions, overlapping lines, etc.). SoS will arbitrarily (but consistently) choose to punt the ray either left or right. The ray will therefore either hit _between_ 'a' and 'b' or it won't hit the edge at all. This PR makes it configurable which direction to punt the ray.