### PR TITLE
fix get_visibility_polygon with Point<f64>

### DIFF
--- a/src/algorithms/visibility/naive.rs
+++ b/src/algorithms/visibility/naive.rs
@@ -153,7 +153,7 @@ where
   T: PolygonScalar,
 {
   let line: Line<T> = sos_line.into();
-  match Point::orient_along_direction(line.origin, line.direction, &edge.src) {
+  match Point::orient_along_direction(line.origin, line.direction, edge.src) {
     Orientation::CoLinear => edge.src.clone(),
     // edge.dst should be colinear with the ray
     _ => edge.dst.clone(),


### PR DESCRIPTION
`get_visibility_polygon` sometimes crashes with `Point<f64>` due to
floating point error. With `Point<f64>`, return value from
`get_intersaction` might be a little closer or further than original
vertex when intersection result is `Crossing`, which results in invalid
`polygon_points` and crash.
