### PR TITLE
ci: build nix lint tools from nixpkgs so fork PRs work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          # Fork PRs cannot use OIDC, so FlakeHub auth always fails there.
+          use-flakehub: false
       - run: nix flake check
 
   pre-commit:
@@ -25,6 +28,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          # Fork PRs cannot use OIDC, so FlakeHub auth always fails there.
+          use-flakehub: false
       - run: nix run .#pre-commit
 
   cargo-publish:
@@ -34,6 +40,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          # Fork PRs cannot use OIDC, so FlakeHub auth always fails there.
+          use-flakehub: false
       - run: nix develop -c cargo publish --dry-run
 
   coverage:
@@ -43,6 +52,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          # Fork PRs cannot use OIDC, so FlakeHub auth always fails there.
+          use-flakehub: false
       - name: Generate coverage report
         run: nix build .#coverage
       - name: Upload coverage to Codecov

--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,5 @@
 {
   "nodes": {
-    "alejandra": {
-      "inputs": {
-        "fenix": "fenix",
-        "flakeCompat": "flakeCompat",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1777149230,
-        "narHash": "sha256-pu6dVB6NrIj90rrqCgJ5pPlBzS76pW4WA6rE1rD1Gp8=",
-        "owner": "kamadorueda",
-        "repo": "alejandra",
-        "rev": "8c4a4a572bee519b04e9bb9207e7d993f55ecb4f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kamadorueda",
-        "repo": "alejandra",
-        "type": "github"
-      }
-    },
     "crane": {
       "locked": {
         "lastModified": 1783203018,
@@ -35,71 +15,9 @@
         "type": "github"
       }
     },
-    "deadnix": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2",
-        "utils": "utils"
-      },
-      "locked": {
-        "lastModified": 1764114543,
-        "narHash": "sha256-+C39E8qmGODT6eB0rhE/VX+DcekXW/Xww5IL/xlERNY=",
-        "owner": "astro",
-        "repo": "deadnix",
-        "rev": "d590041677add62267bef35ddec63cd9402d3505",
-        "type": "github"
-      },
-      "original": {
-        "owner": "astro",
-        "repo": "deadnix",
-        "type": "github"
-      }
-    },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "alejandra",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1768113825,
-        "narHash": "sha256-f09fAifGPEuRrz1DFY910jexq0DaBuQBbq7WcxQIUgs=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "55106e04d905c6a7726d0f6be77ed39a99f66a61",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "statix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -115,55 +33,7 @@
         "type": "github"
       }
     },
-    "flakeCompat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1768129890,
-        "narHash": "sha256-izB67Et12Th6/dwE7FaOuRbk1Rw/aOTYbACw1CANkkY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b4262d9cfe384fd40a13954fda8b0a371601b85e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1763934636,
-        "narHash": "sha256-9glbI7f1uU+yzQCq5LwLgdZqx6svOhZWkd4JRY265fc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ee09932cedcef15aaf476f9343d1dea2cb77e261",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
       "locked": {
         "lastModified": 1767313136,
         "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
@@ -179,7 +49,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -195,53 +65,17 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1755268003,
-        "narHash": "sha256-nNaeJjo861wFR0tjHDyCnHs1rbRtrMgxAKMoig9Sj/w=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "32f313e49e42f715491e1ea7b306a87c16fe0388",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "alejandra": "alejandra",
         "crane": "crane",
-        "deadnix": "deadnix",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_3",
-        "rust-overlay": "rust-overlay",
-        "statix": "statix"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1768083390,
-        "narHash": "sha256-TGWPJq2mXwxfAe83iZ18DIqXC4sOSj7RkW9b59h6Ox4=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "e42e8ff582ba12a88b6845525d08b6428e6d0fb9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1784004965,
@@ -257,26 +91,6 @@
         "type": "github"
       }
     },
-    "statix": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_5",
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1781365523,
-        "narHash": "sha256-ITWSnsfzAKdc18PhoVQDXVNg3WsZkGemmoepDc8vijs=",
-        "owner": "oppiliappan",
-        "repo": "statix",
-        "rev": "580c3762d5c0ea064867ef530c18c57fc61a4df0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oppiliappan",
-        "repo": "statix",
-        "type": "github"
-      }
-    },
     "systems": {
       "locked": {
         "lastModified": 1681028828,
@@ -289,55 +103,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,9 +6,6 @@
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay.url = "github:oxalica/rust-overlay";
     crane.url = "github:ipetkov/crane";
-    alejandra.url = "github:kamadorueda/alejandra";
-    statix.url = "github:oppiliappan/statix";
-    deadnix.url = "github:astro/deadnix";
   };
 
   outputs = {
@@ -17,9 +14,6 @@
     flake-utils,
     rust-overlay,
     crane,
-    alejandra,
-    statix,
-    deadnix,
   }:
     flake-utils.lib.eachDefaultSystem (
       system: let
@@ -141,7 +135,7 @@
            '';
 
          wasmBindgenCli = let
-           version = pkgs.wasm-bindgen-cli.version;
+           inherit (pkgs.wasm-bindgen-cli) version;
          in
            if version == "0.2.100"
            then pkgs.wasm-bindgen-cli
@@ -238,7 +232,7 @@
             default = self.packages.${system}.all-demos;
           };
 
-        formatter = alejandra.defaultPackage.${system};
+        formatter = pkgs.alejandra;
 
         checks = {
           # Run the library tests
@@ -264,19 +258,19 @@
 
           # Check Nix formatting
           alejandra-check = pkgs.runCommand "alejandra-check" {} ''
-            ${alejandra.defaultPackage.${system}}/bin/alejandra --check ${src}
+            ${pkgs.alejandra}/bin/alejandra --check ${src}
             touch $out
           '';
 
           # Check Nix code with statix
           statix-check = pkgs.runCommand "statix-check" {} ''
-            ${statix.packages.${system}.default}/bin/statix check ${./.}
+            ${pkgs.statix}/bin/statix check ${./.}
             touch $out
           '';
 
           # Check for dead Nix code with deadnix
           deadnix-check = pkgs.runCommand "deadnix-check" {} ''
-            ${deadnix.packages.${system}.default}/bin/deadnix --fail ${./.}
+            ${pkgs.deadnix}/bin/deadnix --fail ${./.}
             touch $out
           '';
 


### PR DESCRIPTION
Fork PRs fail `nix flake check` / `nix run .#pre-commit` with `error: cannot download crate-rnix-0.12.0.tar.gz from any mirror` (403).

`statix`, `deadnix` and `alejandra` were separate flake inputs, so their store paths are not on cache.nixos.org and get built from source. Their pinned nixpkgs fetches crates from `https://crates.io/api/v1/crates/<name>/<ver>/download`, which now returns 403 for every crate. Non-fork runs never noticed because FlakeHub Cache had the paths; fork PRs cannot use OIDC, get no cache, and rebuild from source.

Use the nixpkgs versions instead (statix 0.5.8, alejandra 4.0.0, deadnix 1.2.1 — all substitutable from cache.nixos.org), and set `use-flakehub: false` on magic-nix-cache-action so it stops emitting an authentication error on every run.

Drive-by: nixpkgs' statix flags one extra lint (W04) in flake.nix, fixed with `inherit`.

Unblocks #238 and #237 once rebased. Note that #238 has a separate unrelated failure: its new rustdoc job runs `cargo +nightly`, which the nix devshell has no rustup for.